### PR TITLE
feat: add username to x-authenticated-user http header

### DIFF
--- a/nginx_ldap_auth/app/middleware.py
+++ b/nginx_ldap_auth/app/middleware.py
@@ -106,6 +106,10 @@ class SessionMiddleware(StarsessionsSessionMiddleware):
                 f"path={path}",
             ]
 
+            username = scope["session"].get("username")
+            if username:
+                headers.append("X-Authenticated-User", username)
+
             if self.lifetime > 0:  # always send max-age for non-session scoped cookie
                 header_parts.append(f"max-age={remaining_time}")
 


### PR DESCRIPTION
Adds username from session to the X-Authenticated-User HTTP header for use upstream, i.e. for user provisioning and logins in proxy authenticated apps.

fix #7

Note: The username field was easy enough to provide but I did not look into grepping any LDAP attributes.  I also have never worked with starlette, and seldom touch python, so please let me know if I've made any errors or mishaps.  This code does work for me locally, however.

To use with nginx:

```nginx
location / {
    auth_request /check-auth;
    auth_request_set $auth_user $upstream_http_x_authenticated_user;
    proxy_set_header X-Authenticated-User $auth_user;
    # ...
}
```