### PR TITLE
Add option to run the web server with TLS disabled

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -275,6 +275,10 @@ These settings configure the web server that ``nginx-ldap-auth-service`` runs,
 
     Set to ``1`` or ``True`` to enable debug mode. Defaults to ``False``.
 
+.. envvar:: INSECURE
+
+    Set to ``1`` or ``True`` to start the web server with TLS disabled. Defaults to ``False``.
+
 
 Login form and sessions
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/nginx_ldap_auth/cli/server.py
+++ b/nginx_ldap_auth/cli/server.py
@@ -86,7 +86,7 @@ def start(**kwargs):
     }
     if not kwargs["insecure"]:
         # adding in SSL settings results in `uvicorn` running over HTTPS
-        # the SSL settings will bee ignored when insecure mode is enabled
+        # the SSL settings will be ignored when insecure mode is enabled
         ssl_kwargs = {
             "ssl_keyfile": kwargs["keyfile"],
             "ssl_certfile": kwargs["certfile"],


### PR DESCRIPTION
This pull request adds an optional "INSECURE" environment variable that will run the web server with TLS disabled.

Fixes https://github.com/caltechads/nginx-ldap-auth-service/issues/12

The [Uvicorn](https://uvicorn.dev) web server runs over HTTPS when the SSL key and certificate parameters are passed through. Setting "INSECURE" to true omits the SSL parameters, running the server over HTTP instead.

Please let me know if I have missed anything. I have never worked with this Python web stack before.


### Default Behavior

Startup log (server running on HTTPS):

```
2025-09-25T13:06:05.402143Z [info     ] Uvicorn running on https://nginx-ldap-auth-service:8888 (Press CTRL+C to quit) [uvicorn.error]
```

A call against the HTTPS "/check" endpoint (with SSL validation disabled because of the self-signed cert) returns a 401 as expected:

```sh
➜  ~ curl -i -k https://localhost:8888/check
HTTP/1.1 401 Unauthorized
date: Thu, 25 Sep 2025 13:07:36 GMT
server: uvicorn
content-length: 2
content-type: application/json
cache-control: no-cache

{}
```

The same call against the HTTP endpoint returns an empty reply from the server:

```sh
➜  ~ curl -i http://localhost:8888/check
curl: (52) Empty reply from server
```


### Insecure Mode Enabled

When running with the "INSECURE" environment variable set to true.

Startup log (server running on HTTP):

```
2025-09-25T13:10:49.472367Z [info     ] Uvicorn running on http://nginx-ldap-auth-service:8888 (Press CTRL+C to quit) [uvicorn.error]
```

A call against the HTTPS "/check" endpoint now fails:

```sh
➜  ~ curl -i -k https://localhost:8888/check
curl: (35) LibreSSL/3.3.6: error:1404B42E:SSL routines:ST_CONNECT:tlsv1 alert protocol version
```

The same call against the HTTP endpoint now returns a 401 response as expected:

```sh
➜  ~ curl -i http://localhost:8888/check
HTTP/1.1 401 Unauthorized
date: Thu, 25 Sep 2025 13:11:35 GMT
server: uvicorn
content-length: 2
content-type: application/json
cache-control: no-cache

{}
```